### PR TITLE
Feature finally blog feed

### DIFF
--- a/platform/dist/css/main.css
+++ b/platform/dist/css/main.css
@@ -44,7 +44,7 @@ img {
   transform: rotate(90deg) scale(1.1);
 }
 
-header {
+header.header__landing {
   height: 100%;
   height: 100vh;
   color: #333;
@@ -172,6 +172,15 @@ transform: translate(85px, 100px);
 section {
   padding: 100px 0;
 }
+.landing__news ul {
+  list-style: none;
+}
+.landing__news__li {
+  font-size: 18px;
+  display: block;
+  margin-bottom: 10px;
+}
+
 .section--alt {
   color: #3f3f3f;
   background: #f3f2f2;
@@ -531,4 +540,21 @@ margin-bottom: 50px;
 .dashboard__save:hover {
   border: solid 1px #333;
   color: #333;
+}
+
+.blog {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 50px 15px 100px;;
+}
+
+
+.blog h1,
+.blog h2,
+.blog h3,
+.blog h4,
+.blog p,
+.blog img,
+.blog ul {
+  margin-bottom: 20px;
 }

--- a/platform/routes/index.js
+++ b/platform/routes/index.js
@@ -61,6 +61,10 @@ router.get('/dashboard', util.isAuthenticated, (req, res) => {
     })
 });
 
+router.get('/blog/:permlink', (req, res) => {
+  res.render('blog-post', { title: 'Finally Blog', permlink : req.params.permlink} );
+});
+
 router.get('/@:username', (req, res) => {
   const username = req.params.username
   let domain = req.headers.host;

--- a/platform/src/js/main.js
+++ b/platform/src/js/main.js
@@ -1,9 +1,11 @@
 import $ from 'jquery'
+import steem from 'steem'
 
 const app = {
   init() {
     this.UiActions()
     this.showSelectedThemeInDropdown()
+    this.loadNewsLinks()
   },
 
   UiActions() {
@@ -34,7 +36,23 @@ const app = {
         data: { theme, tag }
       },
       (response) => location.reload())
+  },
+
+  loadNewsLinks(){
+    const query = { tag: 'finallynetwork', limit: 5 }
+    const listPosts = (posts) => {
+      for (var i = 0; i < posts.length; i++) {
+        let template = `<li><a href="/blog/${posts[i].url}"> ${posts[i].title}</a></li>`
+        $('.landing__news ul').append(template)
+      }
+    }
+    steem.api.getDiscussionsByBlog(query, (err, result) => {
+      console.log('ho')
+      if (err === null) listPosts(result)
+    })
+
   }
+
 }
 
 app.init()

--- a/platform/src/js/main.js
+++ b/platform/src/js/main.js
@@ -2,6 +2,7 @@ import $ from 'jquery'
 import steem from 'steem'
 import showdown from 'showdown'
 import purify from 'dompurify'
+import finallycomments from 'finallycomments'
 
 const app = {
   init() {
@@ -74,16 +75,29 @@ const app = {
     const post = posts.filter(post => post.permlink === permlink)[0]
     const template = this.singlePostTemplate(post)
     $('main').append(template)
+    this.appendSinglePostComments(post)
   },
 
   singlePostTemplate(post){
     var converter = new showdown.Converter();
     var html = purify.sanitize(converter.makeHtml(post.body))
-    return `<h1>${post.title}</h1>${html}
+    return `<h1>${post.title}</h1>${html}`
+  },
 
-
-    `
-  }
+  appendSinglePostComments(postData) {
+    $('main').append(
+    `<section class="post__comments"
+    data-id="https://steemit.com/${postData.category}/@${postData.author}/${postData.permlink}"
+    data-reputation="false"
+    data-values="false"
+    data-profile="false"
+    data-generated="false"
+    data-beneficiary="finallycomments"
+    data-beneficiaryWeight="25"
+    data-guestComments="false">
+    </section>`)
+      finallycomments.loadEmbed('.post__comments')
+  },
 
 }
 

--- a/platform/src/js/main.js
+++ b/platform/src/js/main.js
@@ -40,17 +40,18 @@ const app = {
 
   loadNewsLinks(){
     const query = { tag: 'finallynetwork', limit: 5 }
-    const listPosts = (posts) => {
-      for (var i = 0; i < posts.length; i++) {
-        let template = `<li><a href="/blog/${posts[i].url}"> ${posts[i].title}</a></li>`
-        $('.landing__news ul').append(template)
-      }
-    }
     steem.api.getDiscussionsByBlog(query, (err, result) => {
-      console.log('ho')
-      if (err === null) listPosts(result)
+      if (err === null) this.loopNewsResults(result)
     })
+  },
 
+  loopNewsResults(posts){
+      posts.forEach( post => this.displayNewsLink(post) )
+  },
+
+  displayNewsLink(post) {
+    const template = `<li><a href="/blog/${post.permlink}"> ${post.title}</a></li>`
+    $('.landing__news ul').append(template)
   }
 
 }

--- a/platform/views/index.pug
+++ b/platform/views/index.pug
@@ -27,9 +27,12 @@ block content
     section.section--alt
       .section__content
         h2 What is Finally?
-        p Finally is a network of content that is powered by the STEEM blockchain.
+        p Finally is a website builder for users of the Steem Blockchain.
 
-        p Create and publish content using any STEEM platform. Within the Finally Network you can create a website with one of the avalible themes. Find a style that best suits your content.  Upgrade to Pro for your own subdomain (example.finally.network) or custom domain (example.com).
+        p Automatically showcase your content from Steemit, Busy, D.tube, Steepshot, Steemhunt (plus many others). Instantly change the look and feel of you content with one of the avalible themes.
+
+        h2 Latest News
+        .landing__news: ul
 
 
     section.section--offbrand

--- a/platform/views/index.pug
+++ b/platform/views/index.pug
@@ -1,7 +1,7 @@
 extends layout
 
 block content
-  header
+  header.header__landing
     .header__overlay
       img(src="/img/finally-brand.png").finally-brand
       .header__left


### PR DESCRIPTION
Adds a blog feed to the finally.network site and individual posts pulled from @finallynetwork account (including resteems) over to `/blog/:permlink` route. 

<img width="1079" alt="screen shot 2018-09-27 at 13 23 14" src="https://user-images.githubusercontent.com/34964560/46145604-922af700-c258-11e8-8bfa-43b777b87c55.png">
<img width="1419" alt="screen shot 2018-09-27 at 13 23 32" src="https://user-images.githubusercontent.com/34964560/46145605-922af700-c258-11e8-9126-ec8c2a1259fb.png">
