### PR TITLE
disable resteems in feeds

### DIFF
--- a/platform/src/js/campfire-theme.js
+++ b/platform/src/js/campfire-theme.js
@@ -25,7 +25,7 @@ async function loadUserPosts(loadMore) {
   const username = $('main').data('username')
   const profileImage = await getSteemProfileImage(username)
   const TAG = $('main').data('tag');
-  
+
   let query = { tag: username, limit: 15 }
   const listPosts = (posts) => {
     if (posts.length < 10) $('.load-more-posts').remove()
@@ -71,9 +71,14 @@ async function loadUserPosts(loadMore) {
     start_permlink: $('tr').last().data('permlink') }
   }
   steem.api.getDiscussionsByBlog(query, (err, result) => {
+    result = filterOutResteems(result, username)
     let posts = TAG !== '' ? filterByTag(result, TAG) : result
     if (err === null) listPosts(posts)
   })
+}
+
+function filterOutResteems(posts, username){
+  return posts.filter(post => post.author === username)
 }
 
 function filterByTag(posts, tag){
@@ -165,10 +170,6 @@ async function appendSingePostContent(post) {
 
   var html = purify.sanitize(converter.makeHtml(post.body))
   let image;
-
-  console.log( 'ehhehe')
-  console.log('post data',  post )
-
 
   if( typeof JSON.parse(post.json_metadata) === 'undefined' ){
     post.body = replaceMarkdownImagesWithHtml(post.body)

--- a/platform/src/js/hckr-theme.js
+++ b/platform/src/js/hckr-theme.js
@@ -72,6 +72,7 @@ const hckr = {
       start_permlink: hckr.lastPermlink }
     }
     steem.api.getDiscussionsByBlog(query, (err, result) => {
+      result = hckr.filterOutResteems(result, hckr.username)
       let posts = hckr.tag !== '' ? hckr.filterByTag(result, hckr.tag) : result
       if (err === null) hckr.loopUserPosts(loadMore, posts)
     })
@@ -82,6 +83,10 @@ const hckr = {
       let tags = JSON.parse(post.json_metadata).tags
       if( tags.includes(tag) || post.parent_permlink === tag ) return post
     })
+  },
+
+  filterOutResteems(posts, username){
+    return posts.filter(post => post.author === username)
   },
 
   loopUserPosts(loadMore, posts){

--- a/platform/src/js/lens-theme.js
+++ b/platform/src/js/lens-theme.js
@@ -34,9 +34,14 @@ $('.overlay__bg').on('click', () => {
 function getBlog(query, initial, callback){
   steem.api.getDiscussionsByBlog(query, (err, result) => {
     if (err) console.log(err)
+    result = filterOutResteems(result, USERNAME)
     let photos = TAG !== '' ? filterByTag(result, TAG) : result
     displayImages(photos, initial, initial ? false : callback)
   });
+}
+
+function filterOutResteems(posts, username){
+  return posts.filter(post => post.author === username)
 }
 
 function filterByTag(posts, tag){


### PR DESCRIPTION
Resteems have been removed from the feed list. They are currently unsupported as Finally recognises the website as the author of the post. Will look at a good way to support resteemed content in the future.