### PR TITLE
Enable resteem content

### DIFF
--- a/platform/controllers/template.js
+++ b/platform/controllers/template.js
@@ -33,3 +33,19 @@ module.exports.renderSingle = (username, permlink, res) => {
     });
   })
 }
+
+module.exports.renderResteem = (username, author, permlink, res) => {
+  User.findOne({user : username}, (err, result) => {
+    if (err) throw (err);
+    const THEME = result && result.theme ? result.theme : DEFAULT_THEME
+    const NAV = result && result.navigation ? result.navigation : []
+    res.render('resteem', {
+      username,
+      author,
+      permlink,
+      theme: THEME,
+      nav: NAV,
+      pro: accountController.accountStatus(result)
+    });
+  })
+}

--- a/platform/controllers/template.js
+++ b/platform/controllers/template.js
@@ -4,16 +4,15 @@ const DEFAULT_THEME = 'campfire'
 
 module.exports.renderProfile = (username, res) => {
   User.findOne({user : username}, (err, result) => {
+    if (result === null ) res.render('profile', { username, theme : DEFAULT_THEME, tag: '', nav : [], pro :false })
     if (err) throw (err);
-    const THEME = result && result.theme ? result.theme : DEFAULT_THEME
-    const TAG = result && result.tag ? result.tag : ''
-    const NAV = result && result.navigation ? result.navigation : []
 
     res.render('profile', {
       username,
-      theme: THEME,
-      tag: TAG,
-      nav: NAV,
+      theme: result.theme,
+      tag: result.tag,
+      nav: result.navigation,
+      showResteems: result.showResteems,
       pro: accountController.accountStatus(result)
     })
   })

--- a/platform/dist/css/make-theme.css
+++ b/platform/dist/css/make-theme.css
@@ -205,9 +205,20 @@ a.nav__link:hover {
 .content {
   padding: 50px;
 }
+
 .content * {
   margin-bottom: 30px;
 }
+
+.content__title {
+  font-size: 2rem;
+}
+
+.content__subtitle {
+  font-size: 14px;
+  margin-bottom: 0
+}
+
 .content img {
   display: block;
   margin: 0 auto 20px auto;

--- a/platform/models/user.js
+++ b/platform/models/user.js
@@ -7,7 +7,8 @@ var userSchema = new Schema({
     theme: String,
     beta: { type: Boolean, default: false },
     tag: { type: String, default: '' },
-    navigation: { type: [String], default: []}
+    navigation: { type: [String], default: []},
+    showResteems: {type: Boolean, default: false}
 });
 
 module.exports = mongoose.model('User', userSchema);

--- a/platform/routes/api.js
+++ b/platform/routes/api.js
@@ -15,12 +15,14 @@ router.post('/:username/update', util.isAuthorized, (req, res) => {
   const theme = req.body.theme
   const tag = req.body.tag
   const nav = req.body.nav.split(',').map(n => n.trim().toLowerCase())
+  const showResteems = req.body.showResteems
 
   if(username === authorizedUser){
     User.findOneAndUpdate({user: username}, {
         theme: theme,
         tag: tag,
-        navigation: nav
+        navigation: nav,
+        showResteems: showResteems
     }, {upsert: true}, (result) => res.json({result}));
   } else {
     res.json({

--- a/platform/routes/index.js
+++ b/platform/routes/index.js
@@ -25,7 +25,8 @@ router.get('/dashboard', util.isAuthenticated, (req, res) => {
         selectedTheme : THEME,
         tag: TAG,
         navigation: NAV.join(','),
-        pro: accountController.accountStatus(result) } );
+        pro: accountController.accountStatus(result),
+        showResteems: result.showResteems  } );
     })
 });
 

--- a/platform/routes/index.js
+++ b/platform/routes/index.js
@@ -59,4 +59,12 @@ router.get('/@:username/:permlink', (req, res) => {
 });
 
 
+router.get('/@:username/resteem/@:author/:permlink', (req, res) => {
+  const username = req.params.username
+  const permlink = req.params.permlink
+  const author = req.params.author
+  templateController.renderResteem(username, author, permlink, res)
+});
+
+
 module.exports = router;

--- a/platform/src/js/campfire-theme.js
+++ b/platform/src/js/campfire-theme.js
@@ -8,6 +8,7 @@ import beta from './modules/finally-try'
 beta.init()
 
 const converter = new showdown.Converter({ tables: true })
+const showRestems = $('main').data('show-resteems')
 
 let page;
 
@@ -73,7 +74,7 @@ async function loadUserPosts(loadMore) {
     start_permlink: $('tr').last().data('permlink') }
   }
   steem.api.getDiscussionsByBlog(query, (err, result) => {
-    result = filterOutResteems(result, username)
+    result = showRestems ? result : filterOutResteems(result, username)
     let posts = TAG !== '' ? filterByTag(result, TAG) : result
     if (err === null) listPosts(posts)
   })

--- a/platform/src/js/hckr-theme.js
+++ b/platform/src/js/hckr-theme.js
@@ -2,6 +2,7 @@ import $ from 'jquery'
 import moment from 'moment'
 
 import f from './modules/finally-core'
+import util from './modules/finally-util'
 
 const hckr = {
   username: $('main').data('username'),
@@ -27,15 +28,20 @@ const hckr = {
   },
 
   blogFeedItemTemplate(post, featureImageSrc, tags, excerpt){
+    const resteem = util.isResteem(hckr.username, post) ? '' : `RESTEEM @${post.author} : `
+    const link = util.getPostLink(hckr.username, post)
+
     return `<div class="blog-feed__item">
-      <h2><a href="/@${hckr.username}/${post.permlink}"> ${post.title}</a></h2>
+      <h2><a href="${link}">${resteem} ${post.title}</a></h2>
       <h3>${moment(post.created).format("DD/MM/YY")  } | comments: ${post.children} | votes: ${post.net_votes}</h3>
     </div>`
   },
 
   singlePageTemplate(post, html){
+    const resteem = util.isResteem(hckr.username, post) ? '' : `RESTEEM @${post.author} : `
     return `<a href="/@${hckr.username}/" class="back-btn">⬅</a>
-    <h2>${post.title}</h2>
+    <h2>${resteem}${post.title}</h2>
+
     ${html}`
   }
 

--- a/platform/src/js/lens-theme.js
+++ b/platform/src/js/lens-theme.js
@@ -19,6 +19,8 @@ let allContent = []
 let allUsers = []
 let msnry, lastTop;
 let $gallery = $('.gallery')
+let showRestems = $('main').data('show-resteems')
+
 
 getBlog(query, true)
 
@@ -36,7 +38,7 @@ $('.overlay__bg').on('click', () => {
 function getBlog(query, initial, callback){
   steem.api.getDiscussionsByBlog(query, (err, result) => {
     if (err) console.log(err)
-    result = filterOutResteems(result, USERNAME)
+    result = showRestems ? result : filterOutResteems(result, USERNAME)
     let photos = TAG !== '' ? filterByTag(result, TAG) : result
     displayImages(photos, initial, initial ? false : callback)
   });

--- a/platform/src/js/main.js
+++ b/platform/src/js/main.js
@@ -51,12 +51,13 @@ const app = {
     const theme = $('.dashboard__theme-select :selected').val();
     const tag = $('.dashboard__tag-select').val();
     const nav = $('.dashboard__nav-select').val();
+    const showResteems = $('.dashboard__resteem-checkbox').is(':checked')
     const username = $('.dashboard').data('username')
     e.preventDefault()
     $.post({
         url: `/api/${username}/update`,
         dataType: 'json',
-        data: { theme, tag, nav }
+        data: { theme, tag, nav, showResteems }
       },
       (response) => location.reload())
   },

--- a/platform/src/js/make-theme.js
+++ b/platform/src/js/make-theme.js
@@ -2,7 +2,7 @@ import $ from 'jquery'
 import moment from 'moment'
 
 import f from './modules/finally-core'
-
+import util from './modules/finally-util'
 
 const make = {
   username: $('main').data('username'),
@@ -45,16 +45,19 @@ const make = {
   },
 
   blogFeedItemTemplate(post, featureImageSrc, tags, excerpt){
+    const resteem = util.isResteem(make.username, post) ? '' : `RESTEEM @${post.author} : `
+    const link = util.getPostLink(make.username, post)
+
     return `
     <div class="blog-feed__item">
-      <a class="feed-item__feature" href="/@${make.username}/${post.permlink}">
+      <a class="feed-item__feature" href="${link}">
         <div class="feed-item__overlay">
           <h3 class="feed-item__overlay-title">Read More</h3>
         </div>
         <img src="https://steemitimages.com/900x500/${featureImageSrc}">
       </a>
       <div class="feed-item__tags">${tags}</div>
-      <h2 class="feed-item__title"><a href="/@${make.username}/${post.permlink}"> ${post.title}</a></h2>
+      <h2 class="feed-item__title"><a href="${link}"">${resteem} ${post.title}</a></h2>
       <div class="feed-item__excerpt">${excerpt}</div>
       <div class="feed-item__interactions">
         <img class="feed-item__heart" src="/img/heart.svg" width="25" height="25">
@@ -64,8 +67,11 @@ const make = {
   },
 
   singlePageTemplate(post, html){
+    const resteem = util.isResteem(make.username, post) ? '' : `<h3 class="content__subtitle">RESTEEM @${post.author}</h3>`
+
     return `
     <section class="content">
+      ${resteem}
       <h2 class="content__title">${post.title}</h2>
       ${html}
     </section>`

--- a/platform/src/js/modules/finally-core.js
+++ b/platform/src/js/modules/finally-core.js
@@ -47,9 +47,14 @@ let theme = {
     return $('main').hasClass('profile')
   },
 
+  isResteemdPost(){
+    return $('main').hasClass('resteem')
+  },
+
   async loadSinglePost(){
     finallycomments.init()
-    const postData = await steem.api.getContentAsync(theme.username, theme.permlink)
+    const author = theme.isResteemdPost() ? $('main').data('author') : theme.username
+    const postData = await steem.api.getContentAsync(author, theme.permlink)
     await theme.appendSingePostContent(postData)
     theme.appendSinglePostComments(postData)
   },
@@ -108,9 +113,8 @@ let theme = {
       start_permlink: theme.lastPermlink }
     }
     steem.api.getDiscussionsByBlog(query, (err, result) => {
-      console.log(result)
-      let resultLessResteems = theme.filterOutResteems(result, theme.username)
-      let posts = theme.tag !== '' ? theme.filterByTag(resultLessResteems, theme.tag) : resultLessResteems
+      result = theme.showRestems ? result : theme.filterOutResteems(result, theme.username)
+      let posts = theme.tag !== '' ? theme.filterByTag(result, theme.tag) : result
       if (err === null) theme.loopUserPosts(loadMore, posts, result.length)
     })
   },

--- a/platform/src/js/modules/finally-core.js
+++ b/platform/src/js/modules/finally-core.js
@@ -12,12 +12,15 @@ const POST_LIMIT = 15;
 const MARKDOWN_SETTINGS = {tables: true}
 let USE_BACKGROUND_PHOTO = false;
 
+// const CONTAINER = $('main')
+
 let theme = {
   permlink: $('main').data('permlink'),
   username: $('main').data('username'),
   name: $('main').data('theme'),
   tag: $('main').data('tag'),
   lastPermlink: '',
+  showRestems: $('main').data('show-resteems'),
 
   init(){
     beta.init()

--- a/platform/src/js/modules/finally-util.js
+++ b/platform/src/js/modules/finally-util.js
@@ -1,0 +1,7 @@
+module.exports.getPostLink = (username, post) => {
+   return username === post.author ? `/@${username}/${post.permlink}` : `/@${username}/resteem/@${post.author}/${post.permlink}`
+}
+
+module.exports.isResteem = (username, post ) => {
+  return username === post.author
+}

--- a/platform/views/dashboard.pug
+++ b/platform/views/dashboard.pug
@@ -12,6 +12,7 @@ block content
           tr
             th Website
             th Theme
+            th Show Resteems
             th(title="specify a hashtag to use for your blog") Hashtag Filter
             th(title="list of tags for navigation") Navigation
             th
@@ -23,8 +24,9 @@ block content
                 option(value="hckr") HCKR
                 option(value="campfire") Campfire
                 option(value="make") Make
+              td: input.dashboard__resteem-checkbox(type="checkbox" name="resteem" checked=(showResteems))
             td
-              span #
+              span
               input.dashboard__input.dashboard__tag-select(type="text" value=`${tag}` placeholder="e.g photography")
             td
               input.dashboard__input.dashboard__nav-select(type="text" value=`${navigation}` placeholder="e.g photography, travel")

--- a/platform/views/profile.pug
+++ b/platform/views/profile.pug
@@ -1,5 +1,11 @@
 extends layout
 
 block content
-  header
-  main.profile(data-theme=`${theme}` data-username=`${username}` data-pro=`${pro}` data-tag=`${tag}` data-nav=`${nav}`)
+  main.profile(
+    data-theme=`${theme}`
+    data-username=`${username}`
+    data-pro=`${pro}`
+    data-tag=`${tag}`
+    data-nav=`${nav}`
+    data-show-resteems=`${showResteems}`
+  )

--- a/platform/views/resteem.pug
+++ b/platform/views/resteem.pug
@@ -1,0 +1,11 @@
+extends layout
+
+block content
+  main.resteem(
+      data-theme=`${theme}`
+      data-username=`${username}`
+      data-author=`${author}`
+      data-permlink=`${permlink}`
+      data-pro=`${pro}`
+      data-nav=`${nav}`
+  )


### PR DESCRIPTION
Closes #7  🙌

Re-implemented re-blogged (aka resteem) content as an option in the user dashboard.
decided on a custom single page routes of `/@:username/resteem/@:author/:permlink` the username parameter is kept for prosperity to know whos site we are viewing. The author/permlink relate to the content author. 

`/@:username/resteem/@:author/:permlink`  - Would use the @usernames website/theme and settings. Also can/will show a banner, badge or theme styling of choice to differentiate.

some code duplication. Need to bring Campfire/Lens functions into util or core modules.  #11