### PR TITLE
fix - check for hash on user entry for dashboard hashtag

### DIFF
--- a/platform/modules/util.js
+++ b/platform/modules/util.js
@@ -23,3 +23,8 @@ module.exports.subdomainCheck = (req, res, next) => {
   res.locals.hasSubDomain = hasSubDomain
   next();
 }
+
+module.exports.removeFirstCharIfHash = (string) => {
+  let charOne = string.substr(0, 1)
+  return charOne === '#' ?  string.substr(1, string.length) : string
+}

--- a/platform/routes/api.js
+++ b/platform/routes/api.js
@@ -9,11 +9,12 @@ router.post('/:username/create', (req, res) => {
   User.create({user: username, theme: theme}, (err, result) => res.json({result}))
 });
 
+
 router.post('/:username/update', util.isAuthorized, (req, res) => {
   const username = req.params.username
   const authorizedUser = req.session.steemconnect.name
   const theme = req.body.theme
-  const tag = req.body.tag
+  const tag = util.removeFirstCharIfHash(req.body.tag)
   const nav = req.body.nav.split(',').map(n => n.trim().toLowerCase())
   const showResteems = req.body.showResteems
 


### PR DESCRIPTION
Noticed it was possible and likely a user may enter a hashtag when selecting a filter via the dashboard. PR auto removes first char if it's a hash. extra hash causes steem API to hang. 

<img width="932" alt="screen shot 2018-10-13 at 19 09 48" src="https://user-images.githubusercontent.com/34964560/46907965-8a877580-cf1b-11e8-8d80-0b946b479e0d.png">
